### PR TITLE
fix(dashboard): use device_name from config instead of hardcoded AS10

### DIFF
--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -27,7 +27,7 @@ const MODE_LABELS: Record<string, string> = {
             MlIntelligenceComponent],
   template: `
     <div class="dashboard">
-      <h2>ResMed AirSense 10 Sleep Therapy</h2>
+      <h2>{{ deviceName }} Sleep Therapy</h2>
       <div class="dash-subtitle" *ngIf="data">Last Session - {{ formatDate(data.latest_night.date) }}</div>
 
       <!-- Live Session Banner -->
@@ -180,6 +180,7 @@ export class DashboardComponent implements OnInit, AfterViewInit {
   @ViewChild('eventsPie') eventsPieRef!: ElementRef<HTMLCanvasElement>;
 
   data: DashboardData | null = null;
+  deviceName = 'CPAP'; // overridden from /api/config in ngOnInit
   liveSession: SessionListItem | null = null;
   liveSpO2 = '';
   liveHR = '';
@@ -226,6 +227,17 @@ export class DashboardComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
+    // Load device name from config so the title reflects the actual machine
+    // (e.g. "ResMed AirSense 11 AutoSet Sleep Therapy" instead of hardcoded model).
+    this.api.getConfig().subscribe({
+      next: (cfg) => {
+        if (cfg?.device_name) {
+          this.deviceName = cfg.device_name;
+        }
+      },
+      error: () => {},
+    });
+
     // Check for live session + O2Ring data
     this.api.getRealtime().subscribe({
       next: (rt) => {


### PR DESCRIPTION
## Problem

The dashboard h2 title is hardcoded to `ResMed AirSense 10 Sleep Therapy` in `frontend/src/app/pages/dashboard/dashboard.component.ts`:

```html
<h2>ResMed AirSense 10 Sleep Therapy</h2>
```

This is incorrect for any user with a different machine. My `Identification.json` (and corresponding `device_name` in `config.json`) reports `ResMed AirSense 11 AutoSet`, but the dashboard still says AirSense 10. The Settings page placeholder is already `ResMed AirSense 11`, so the upstream half-fixed it — this finishes the job by sourcing the title from config dynamically.

## Fix

- Add a `deviceName` property on `DashboardComponent` with a sensible `CPAP` fallback.
- Subscribe to `CpapApiService.getConfig()` in `ngOnInit()` and bind `deviceName = cfg.device_name`.
- Template now reads `{{ deviceName }} Sleep Therapy`.

No new dependencies, no new endpoints — uses the existing `/api/config` route.

## Test plan

1. Build the frontend (`npx ng build --configuration production`).
2. Run hms-cpap with a `config.json` whose `device_name` is set to any value other than \"ResMed AirSense 10\" (e.g. \"ResMed AirSense 11 AutoSet\").
3. Load the dashboard — the h2 title should show \"<your device_name> Sleep Therapy\".
4. If `/api/config` is unreachable, the title falls back to \"CPAP Sleep Therapy\" (no crash, no broken layout).

## Related

Discovered while migrating my own deployment from a falsely-labelled AirSense 10 device row to the correct AirSense 11. See `/api/config` already exposing `device_name` and the Settings page binding to it as proof this is the intended canonical source.