### PR TITLE
Fix missing database relation (Current database schemas do not include spo2_drops within cpap_session_metrics)

### DIFF
--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS cpap_session_metrics (
     time_in_apnea_percent  FLOAT,
     avg_spo2               FLOAT,
     min_spo2               FLOAT,
+    spo2_drops             FLOAT,
     avg_heart_rate         INT,
     max_heart_rate         INT,
     min_heart_rate         INT,

--- a/scripts/schema_mysql.sql
+++ b/scripts/schema_mysql.sql
@@ -56,6 +56,7 @@ CREATE TABLE IF NOT EXISTS cpap_session_metrics (
     time_in_apnea_percent  DOUBLE,
     avg_spo2               DOUBLE,
     min_spo2               DOUBLE,
+    spo2_drops             FLOAT,
     avg_heart_rate         INT,
     max_heart_rate         INT,
     min_heart_rate         INT,

--- a/scripts/schema_sqlite.sql
+++ b/scripts/schema_sqlite.sql
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS cpap_session_metrics (
     time_in_apnea_percent  REAL,
     avg_spo2               REAL,
     min_spo2               REAL,
+    spo2_drops             FLOAT,
     avg_heart_rate         INTEGER,
     max_heart_rate         INTEGER,
     min_heart_rate         INTEGER,


### PR DESCRIPTION
# Issue description
Hi there! Just tried implementing HMS-CPAP as an OCI container in Proxmox, and after starting the data ingest, ran into some issues with PostgreSQL and the database created by the current schema, as none of the available .sql files include the `spo2_drops` column within `cpap_session_metrics`.

# Steps to reproduce
1. Deploy the container with an external database.
2. Force data processing through either the Web UI or the container's CLI.
3. Watch the logs for database errors
4. Receive the following as output:
```bash
⚠️  CPAP: Failed to save session to DB
💾 DB: Saving session...
   Session ID: 598
   Breathing summaries: 165
   Calculated metrics saved (RR, TV, MV, Ti/Te, I:E, FL, P95)
   Events: 4
   Vitals: 9900
❌ DB: Failed to save session: ERROR:  column "spo2_drops" of relation "cpap_session_metrics" does not exist
LINE 6:          avg_target_ventilation, therapy_mode, spo2_drops, o...
                                                       ^
```
# Expected vs actual behavior
The session data should be saved properly to the PostgreSQL database, and show the following output in the log:
```bash
✅ DB: Session saved successfully
💾 CPAP: Saved 1/1 session(s) to database
```
# Environment details (OS, Docker version, etc.)
`Proxmox 9.2.4 Linux pve 7.0.14-3-pve #1 SMP PREEMPT_DYNAMIC PMX 7.0.14-3 (2026-07-03T19:51Z) x86_64 GNU/Linux`