### PR TITLE
fix(discovery): survive unreadable DATALOG folders instead of crash-looping

### DIFF
--- a/src/services/BurstCollectorService.cpp
+++ b/src/services/BurstCollectorService.cpp
@@ -1398,8 +1398,21 @@ void BurstCollectorService::runLoop() {
         // Hot-reload config if changed via web UI
         reloadConfig();
 
-        // Execute burst cycle
-        bool success = executeBurstCycle();
+        // Execute burst cycle. Never let an exception escape: this is a
+        // std::thread body, so anything uncaught calls std::terminate and
+        // takes the whole service down (incident 2026-07-17: an unreadable
+        // DATALOG folder crash-looped the container this way). A failed
+        // cycle logs and retries on the normal schedule.
+        bool success = false;
+        try {
+            success = executeBurstCycle();
+        } catch (const std::exception& e) {
+            std::cerr << "CPAP: ❌ Burst cycle failed: " << e.what()
+                      << " — will retry next cycle" << std::endl;
+        } catch (...) {
+            std::cerr << "CPAP: ❌ Burst cycle failed with unknown error"
+                      << " — will retry next cycle" << std::endl;
+        }
 
         if (success) {
             last_burst_time_ = std::chrono::system_clock::now();

--- a/src/services/SessionDiscoveryService.cpp
+++ b/src/services/SessionDiscoveryService.cpp
@@ -442,12 +442,32 @@ SessionDiscoveryService::discoverLocalSessions(
     std::vector<std::string> date_folders;
     std::regex date_regex(R"(^\d{8}$)");
 
-    for (const auto& entry : std::filesystem::directory_iterator(local_datalog_dir)) {
-        if (!entry.is_directory()) continue;
+    // Iterate with error_code: an unreadable DATALOG dir must degrade to an
+    // empty scan, not an uncaught filesystem_error that kills the burst
+    // worker (incident 2026-07-17: root-owned 0750 upload crash-looped the
+    // service).
+    std::error_code dir_ec;
+    std::filesystem::directory_iterator root_it(local_datalog_dir, dir_ec);
+    if (dir_ec) {
+        std::cerr << "CPAP: ⚠️  Cannot read local directory " << local_datalog_dir
+                  << " (" << dir_ec.message()
+                  << ") — fix ownership/permissions so the service user can read it"
+                  << std::endl;
+        return {};
+    }
+    for (; root_it != std::filesystem::directory_iterator();
+         root_it.increment(dir_ec)) {
+        const auto& entry = *root_it;
+        std::error_code entry_ec;
+        if (!entry.is_directory(entry_ec) || entry_ec) continue;
         std::string name = entry.path().filename().string();
         if (std::regex_match(name, date_regex)) {
             date_folders.push_back(name);
         }
+    }
+    if (dir_ec) {
+        std::cerr << "CPAP: ⚠️  Listing of " << local_datalog_dir
+                  << " ended early (" << dir_ec.message() << ")" << std::endl;
     }
 
     std::sort(date_folders.begin(), date_folders.end());
@@ -510,7 +530,18 @@ SessionDiscoveryService::discoverLocalSessions(
         std::string folder_path = local_datalog_dir + "/" + folder;
         std::cout << "CPAP: Scanning local folder " << folder << "..." << std::endl;
 
-        auto folder_sessions = groupLocalFolder(folder_path, folder);
+        // Belt-and-braces: groupLocalFolder degrades gracefully itself, but a
+        // scan surprise in one folder must never abort discovery of the rest
+        // (an escape here reaches the burst worker thread and terminates the
+        // whole process).
+        std::vector<SessionFileSet> folder_sessions;
+        try {
+            folder_sessions = groupLocalFolder(folder_path, folder);
+        } catch (const std::exception& e) {
+            std::cerr << "CPAP: ⚠️  Skipping folder " << folder
+                      << " after scan error: " << e.what() << std::endl;
+            continue;
+        }
         std::cout << "CPAP: Found " << folder_sessions.size()
                   << " sessions in " << folder << std::endl;
 
@@ -595,8 +626,25 @@ SessionDiscoveryService::groupLocalFolder(
         return std::chrono::system_clock::from_time_t(std::mktime(&tm));
     };
 
-    for (const auto& entry : std::filesystem::directory_iterator(dir_path)) {
-        if (!entry.is_regular_file()) continue;
+    // Iterate with error_code (mirrors the SleepHq/Prisma scans): a date
+    // folder the service user cannot open — e.g. uploaded root-owned 0750 —
+    // is skipped with a warning instead of throwing an uncaught
+    // filesystem_error that terminates the service (incident 2026-07-17).
+    std::error_code dir_ec;
+    std::filesystem::directory_iterator dir_it(dir_path, dir_ec);
+    if (dir_ec) {
+        std::cerr << "CPAP: ⚠️  Skipping unreadable folder " << dir_path
+                  << " (" << dir_ec.message()
+                  << ") — fix ownership/permissions so the service user can read it"
+                  << std::endl;
+        return {};
+    }
+
+    for (; dir_it != std::filesystem::directory_iterator();
+         dir_it.increment(dir_ec)) {
+        const auto& entry = *dir_it;
+        std::error_code entry_ec;
+        if (!entry.is_regular_file(entry_ec) || entry_ec) continue;
 
         std::string filename = entry.path().filename().string();
         std::string name_lower = filename;
@@ -605,7 +653,9 @@ SessionDiscoveryService::groupLocalFolder(
         std::string prefix = extractPrefix(filename);
         if (prefix.empty()) continue;
 
-        int size_kb = static_cast<int>(std::filesystem::file_size(entry.path()) / 1024);
+        auto file_bytes = std::filesystem::file_size(entry.path(), entry_ec);
+        if (entry_ec) continue;
+        int size_kb = static_cast<int>(file_bytes / 1024);
 
         if (name_lower.find("_csl.edf") != std::string::npos) {
             csl_files[prefix] = {filename, size_kb};
@@ -627,7 +677,8 @@ SessionDiscoveryService::groupLocalFolder(
             // fs mtime -> system_clock (C++17: bridge via the two clocks' nows).
             // A copied file's mtime is the copy time, not therapy time -- the
             // plausibility gate in estimateCheckpointEnd discards it then.
-            auto ftime = entry.last_write_time();
+            auto ftime = entry.last_write_time(entry_ec);
+            if (entry_ec) continue;
             auto mtime = std::chrono::time_point_cast<std::chrono::system_clock::duration>(
                 ftime - std::filesystem::file_time_type::clock::now()
                 + std::chrono::system_clock::now());
@@ -638,6 +689,11 @@ SessionDiscoveryService::groupLocalFolder(
             cp.is_sad = is_sad;
             checkpoints.push_back(cp);
         }
+    }
+
+    if (dir_ec) {
+        std::cerr << "CPAP: ⚠️  Scan of " << dir_path << " ended early ("
+                  << dir_ec.message() << ")" << std::endl;
     }
 
     if (checkpoints.empty()) return {};

--- a/tests/services/test_SessionDiscoveryService.cpp
+++ b/tests/services/test_SessionDiscoveryService.cpp
@@ -6,6 +6,9 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#ifndef _WIN32
+#include <unistd.h>  // geteuid — UnreadableFolderTest skips under root
+#endif
 
 using namespace hms_cpap;
 namespace fs = std::filesystem;
@@ -490,6 +493,94 @@ TEST_F(DiscoverLocalSessionsTest, OlderSessionInRelevantFolderIsFilteredOut) {
     auto sessions = SessionDiscoveryService::discoverLocalSessions(root, last);
     EXPECT_TRUE(sessions.empty());
 }
+
+// ── Incident 2026-07-17: unreadable date folder crash-looped the service ─────
+// DATALOG date folders uploaded root-owned 0750 made the burst cycle throw an
+// uncaught std::filesystem_error from directory_iterator ("cannot open
+// directory: Permission denied [/data/sdcard/DATALOG/20260627]"), terminating
+// the process every cycle. Discovery must skip unreadable folders with a
+// warning and keep processing the readable ones.
+#ifndef _WIN32
+
+class UnreadableFolderTest : public ::testing::Test {
+protected:
+    std::string root;  // simulated DATALOG dir
+
+    void SetUp() override {
+        root = "/tmp/cpap_test_unreadable_" + std::to_string(getpid());
+        fs::create_directories(root);
+    }
+
+    void TearDown() override {
+        // Re-add owner perms (root first, then children) so remove_all can
+        // descend into folders the tests locked down.
+        std::error_code ec;
+        fs::permissions(root, fs::perms::owner_all, fs::perm_options::add, ec);
+        for (const auto& e : fs::directory_iterator(root, ec)) {
+            fs::permissions(e.path(), fs::perms::owner_all,
+                            fs::perm_options::add, ec);
+        }
+        fs::remove_all(root, ec);
+    }
+
+    std::string makeDateFolder(const std::string& yyyymmdd) {
+        std::string p = root + "/" + yyyymmdd;
+        fs::create_directories(p);
+        return p;
+    }
+};
+
+TEST_F(UnreadableFolderTest, GroupLocalFolderSkipsUnreadableFolder) {
+    if (::geteuid() == 0) GTEST_SKIP() << "permission bits do not bind for root";
+
+    std::string dir = makeDateFolder("20260627");
+    touchFile(dir, "20260627_234552_BRP.edf");
+    fs::permissions(dir, fs::perms::none);  // mimic root-owned 0750 upload
+
+    std::vector<SessionFileSet> sessions;
+    EXPECT_NO_THROW(
+        sessions = SessionDiscoveryService::groupLocalFolder(dir, "20260627"));
+    EXPECT_TRUE(sessions.empty());
+}
+
+TEST_F(UnreadableFolderTest, DiscoverLocalSessionsContinuesPastUnreadableFolder) {
+    if (::geteuid() == 0) GTEST_SKIP() << "permission bits do not bind for root";
+
+    // Readable folder before the bad one (like 20260625 in the incident)...
+    std::string before = makeDateFolder("20260625");
+    touchFile(before, "20260625_232620_BRP.edf");
+    // ...the unreadable upload...
+    std::string bad = makeDateFolder("20260627");
+    touchFile(bad, "20260627_234552_BRP.edf");
+    // ...and a readable folder sorting after it, which the crashing code
+    // never reached.
+    std::string after = makeDateFolder("20260701");
+    touchFile(after, "20260701_010000_BRP.edf");
+
+    fs::permissions(bad, fs::perms::none);
+
+    std::vector<SessionFileSet> sessions;
+    ASSERT_NO_THROW(
+        sessions = SessionDiscoveryService::discoverLocalSessions(root, std::nullopt));
+
+    // Both readable folders contribute their session; the bad one is skipped.
+    ASSERT_EQ(sessions.size(), 2u);
+    EXPECT_EQ(sessions[0].session_prefix, "20260625_232620");
+    EXPECT_EQ(sessions[1].session_prefix, "20260701_010000");
+}
+
+TEST_F(UnreadableFolderTest, DiscoverLocalSessionsSurvivesUnreadableRoot) {
+    if (::geteuid() == 0) GTEST_SKIP() << "permission bits do not bind for root";
+
+    fs::permissions(root, fs::perms::none);
+
+    std::vector<SessionFileSet> sessions;
+    EXPECT_NO_THROW(
+        sessions = SessionDiscoveryService::discoverLocalSessions(root, std::nullopt));
+    EXPECT_TRUE(sessions.empty());
+}
+
+#endif  // !_WIN32
 
 // ── discoverNewSessions: ezShare path via a fake IDataSource ─────────────────
 


### PR DESCRIPTION
## Problem

In local-source mode, a DATALOG date folder the service user cannot read crashes the whole service — and because the burst cycle re-runs on schedule, it becomes a container crash loop.

Real incident (2026-07-17, Docker deployment, AirSense data): date folders copied into the SD-card volume as `root:root` mode `0750`, while the container process runs as user `cpap` (uid 1000). Every burst cycle:

```
CPAP: Scanning local folder 20260627...
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: directory iterator cannot open directory: Permission denied [/data/sdcard/DATALOG/20260627]
```

The container died (exit 139) and restarted every ~65 s — 80+ restarts until the folder permissions were fixed by hand. One unreadable folder also meant *no* folder after it was ever scanned.

## Root cause

- `SessionDiscoveryService::groupLocalFolder` and `discoverLocalSessions` construct `std::filesystem::directory_iterator` with the throwing overloads and no handler.
- The exception escapes `BurstCollectorService::runLoop`, which is a `std::thread` body — an exception escaping a thread calls `std::terminate`, taking down the whole service.

## Fix

Three layers, smallest-possible diff:

1. **`groupLocalFolder`** — iterate with the `std::error_code` overloads (the same idiom `SleepHqExportService` / `PrismaIngestion` already use). An unreadable folder logs `CPAP: ⚠️  Skipping unreadable folder <path> (Permission denied) — fix ownership/permissions so the service user can read it` and returns no sessions; per-file `is_regular_file`/`file_size`/`last_write_time` failures skip just that file.
2. **`discoverLocalSessions`** — same `error_code` treatment for the DATALOG root listing (unreadable root ⇒ warning + empty scan), plus a belt-and-braces `try/catch` around each per-folder scan so one bad folder can never abort discovery of the remaining folders.
3. **`BurstCollectorService::runLoop`** — catch anything a burst cycle throws at the thread boundary, log it, and retry on the normal schedule. No future per-cycle surprise should ever `std::terminate` the service.

`BackfillService` and the HTTP controllers were reviewed too: their DATALOG scans are already wrapped (backfill catches into its progress status; drogon catches handler exceptions), and they gain the per-folder resilience from (1) for free.

## Tests

`UnreadableFolderTest` (in `tests/services/test_SessionDiscoveryService.cpp`) reproduces the incident:

- `GroupLocalFolderSkipsUnreadableFolder` — mode-`0000` date folder ⇒ no throw, empty result.
- `DiscoverLocalSessionsContinuesPastUnreadableFolder` — readable folder, unreadable folder, readable folder **after** it ⇒ both readable folders' sessions returned (the after-folder is the regression the incident exposed).
- `DiscoverLocalSessionsSurvivesUnreadableRoot` — unreadable DATALOG root ⇒ no throw, empty result.

The suite is `#ifndef _WIN32` (permission-bit semantics) and `GTEST_SKIP`s under root, where permission bits don't bind (CI runners are non-root, so they run there).

Verified red→green on Ubuntu 24.04 with the CI package set: all three fail with the incident's exact `filesystem_error` before the fix, pass after, and the full unit gate (CI filter) passes: **744 tests, 0 failures**.

## Version / changelog

Left untouched — bumping looks like a maintainer step here. Suggested entry if useful:

> **An unreadable DATALOG date folder no longer crash-loops the service.** Local-source discovery now iterates with `std::error_code`: an unreadable folder is skipped with a "fix ownership/permissions" warning while remaining folders still ingest, and the burst worker catches per-cycle exceptions at the thread boundary instead of letting them `std::terminate` the process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
